### PR TITLE
docs: add troubleshooting section for clawhub rate limit error

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,3 +117,13 @@ Prompt injection and arbitrary code execution are structurally impossible: the e
 ## Documentation
 
 See [SKILL.md](SKILL.md) for detailed usage instructions and examples.
+
+
+## Troubleshooting
+
+### Installation: Rate limit exceeded
+If you encounter a `Rate limit exceeded` error when running the `npx clawhub@latest install` command, it means the Clawhub registry API is currently experiencing high traffic. 
+
+**Workarounds:**
+1. **Cooldown:** Wait for 15-30 minutes before attempting the installation again.
+2. **Change Network:** The rate limit is often IP-based. Switching to a different network (e.g., mobile hotspot) to obtain a fresh IP address can bypass the restriction.


### PR DESCRIPTION
Hi team! I noticed many users (including myself) are hitting a 'Rate limit exceeded' error when trying to install the skill via Clawhub API during peak hours. I've added a quick troubleshooting section in the README to help new users understand the issue and provide simple workarounds (cooldown/IP change). Hope this helps the community!