### PR TITLE
Fix missing newline at end of evaluate-skill.yml

### DIFF
--- a/.github/workflows/evaluate-skill.yml
+++ b/.github/workflows/evaluate-skill.yml
@@ -63,3 +63,4 @@ jobs:
             echo "- results.json not found" >> "$GITHUB_STEP_SUMMARY"
             exit 1
           fi
+          


### PR DESCRIPTION
Add a newline at the end of the evaluate-skill.yml file.